### PR TITLE
Update tooltip.js

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -24,5 +24,5 @@ export function createTooltipHTML({ name, groupNumber, nodeMeasure }) {
   tooltip.appendChild(groupNumberEntry);
   tooltip.appendChild(nodeMeasureEntry);
 
-  return tooltip.innerHTML;
+  return tooltip;
 }


### PR DESCRIPTION
Qlik Cloud: Network charts showing tags when howering

## Description
The hovering is used to show the dimension values. This functionality is not working fine in the Cloud.

[QB-11333](https://jira.qlikdev.com/browse/QB-11333) 

Attached image for Reference.

<img width="1552" alt="Screenshot 2022-07-25 at 1 42 29 PM" src="https://user-images.githubusercontent.com/98093536/180730297-50e12629-0c40-4714-834d-e822c712ee6d.png">

